### PR TITLE
Optional parameter to await completion in bandwidth plugin before sending beacon

### DIFF
--- a/doc/api/BW.html
+++ b/doc/api/BW.html
@@ -75,6 +75,14 @@ is sent over SSL, then running the test over SSL probably gets you what you want
 set <code>test_https</code> to <code>true</code>, boomerang will run the test instead of skipping.
 </dd>
 
+<dt>block_beacon</dt>
+<dd>
+<strong>[optional]</strong>
+By default, the bandwidth plugin will not block boomerang from sending a beacon, so the results
+will not be included in the broadcast with default settings. If you set <code>block_beacon</code> to
+<code>true</code>, boomerang will wait for the results of the test before sending the beacon.
+</dd>
+
 </dl>
 
 

--- a/doc/howtos/howto-3.html
+++ b/doc/howtos/howto-3.html
@@ -28,7 +28,10 @@ that by measuring not just the bandwidth, but also the error value in that measu
 
 <p>
 Simply adding boomerang to a page and calling the <code>init()</code> method is sufficient to start the bandwidth
-test and beacon its results back to the server.  This is the code you'd use:
+test. If you want the beacon results to include the results of the bandwidth test, setting <code>block_beacon</code>
+to <code>true</code> will force boomerang to wait for the test to complete before sending the beacon. If you do not
+turn on the <code>block_beacon</code> feature, you will only receive bandwidth results if they were cached in a
+cookie by a previous test run.
 </p>
 <pre>
 &lt;script src="boomerang.js" type="text/javascript"&gt;&lt;/script&gt;
@@ -36,7 +39,8 @@ test and beacon its results back to the server.  This is the code you'd use:
 BOOMR.init({
 	beacon_url: "http://yoursite.com/path/to/beacon.php",
 	BW: {
-		base_url: "http://base_url/to/bandwidth/images/"
+		base_url: "http://base_url/to/bandwidth/images/",
+		block_beacon: true
 	}
 });
 &lt;/script&gt;

--- a/doc/howtos/howto-6.html
+++ b/doc/howtos/howto-6.html
@@ -210,6 +210,23 @@ the same time increases the risk that the test will timeout.  It should take abo
 value along with the <code>timeout</code> value above.
 </dd>
 
+<dt>test_https</dt>
+<dd>
+<strong>[optional]</strong>
+By default, boomerang will skip the bandwidth test over an HTTPS connection. Establishing
+an SSL connection takes time, which could skew the bandwidth results. If all your traffic
+is sent over SSL, then running the test over SSL probably gets you what you want. If you
+set <code>test_https</code> to <code>true</code>, boomerang will run the test instead of skipping.
+</dd>
+
+<dt>block_beacon</dt>
+<dd>
+<strong>[optional]</strong>
+By default, the bandwidth plugin will not block boomerang from sending a beacon, so the results
+will not be included in the broadcast with default settings. If you set <code>block_beacon</code> to
+<code>true</code>, boomerang will wait for the results of the test before sending the beacon.
+</dd>
+
 </dl>
 
 <h2>All optional</h2>

--- a/plugins/bw.js
+++ b/plugins/bw.js
@@ -55,8 +55,7 @@ impl = {
 	nruns: 5,
 	latency_runs: 10,
 	user_ip: "",
-	run_always: false,
-	block_for_beacon: false,
+	block_beacon: false,
 	test_https: false,
 	cookie_exp: 7*86400,
 	cookie: "BA",
@@ -414,7 +413,7 @@ impl = {
 
 		this.complete = true;
 
-		if (this.block_for_beacon === true)
+		if (this.block_beacon === true)
 			BOOMR.sendBeacon();
 
 		this.running = false;
@@ -485,18 +484,10 @@ BOOMR.plugins.BW = {
 		}
 
 		BOOMR.utils.pluginConfig(impl, config, "BW",
-						["base_url", "timeout", "nruns", "cookie", "cookie_exp", "test_https"]);
+						["base_url", "timeout", "nruns", "cookie", "cookie_exp", "test_https", "block_beacon"]);
 
 		if(config && config.user_ip) {
 			impl.user_ip = config.user_ip;
-		}
-
-		if(config && config.BW && config.BW.run_always) {
-			impl.run_always = config.BW.run_always;
-		}
-
-		if(config && config.BW && config.BW.block_for_beacon) {
-			impl.block_for_beacon = config.BW.block_for_beacon;
 		}
 
 		if(!impl.base_url) {
@@ -513,7 +504,7 @@ BOOMR.plugins.BW = {
 
 		BOOMR.removeVar("ba", "ba_err", "lat", "lat_err");
 
-		if(impl.run_always || !impl.setVarsFromCookie()) {
+		if(!impl.setVarsFromCookie()) {
 			BOOMR.subscribe("page_ready", this.run, null, this);
 		}
 
@@ -541,7 +532,7 @@ BOOMR.plugins.BW = {
 			BOOMR.info("HTTPS detected, skipping bandwidth test", "bw");
 			impl.complete = true;
 
-			if (impl.block_for_beacon === true)
+			if (impl.block_beacon === true)
 				BOOMR.sendBeacon();
 
 			return this;
@@ -567,7 +558,7 @@ BOOMR.plugins.BW = {
 	},
 
 	is_complete: function() {
-		if (impl.block_for_beacon === true)
+		if (impl.block_beacon === true)
 		{
 			return impl.complete;
 		}

--- a/plugins/bw.js
+++ b/plugins/bw.js
@@ -55,6 +55,8 @@ impl = {
 	nruns: 5,
 	latency_runs: 10,
 	user_ip: "",
+	run_always: false,
+	block_for_beacon: false,
 	test_https: false,
 	cookie_exp: 7*86400,
 	cookie: "BA",
@@ -411,7 +413,10 @@ impl = {
 		}
 
 		this.complete = true;
-		//BOOMR.sendBeacon();
+
+		if (this.block_for_beacon === true)
+			BOOMR.sendBeacon();
+
 		this.running = false;
 	},
 
@@ -486,6 +491,14 @@ BOOMR.plugins.BW = {
 			impl.user_ip = config.user_ip;
 		}
 
+		if(config && config.BW && config.BW.run_always) {
+			impl.run_always = config.BW.run_always;
+		}
+
+		if(config && config.BW && config.BW.block_for_beacon) {
+			impl.block_for_beacon = config.BW.block_for_beacon;
+		}
+
 		if(!impl.base_url) {
 			return this;
 		}
@@ -500,7 +513,7 @@ BOOMR.plugins.BW = {
 
 		BOOMR.removeVar("ba", "ba_err", "lat", "lat_err");
 
-		if(!impl.setVarsFromCookie()) {
+		if(impl.run_always || !impl.setVarsFromCookie()) {
 			BOOMR.subscribe("page_ready", this.run, null, this);
 		}
 
@@ -527,7 +540,10 @@ BOOMR.plugins.BW = {
 
 			BOOMR.info("HTTPS detected, skipping bandwidth test", "bw");
 			impl.complete = true;
-			//BOOMR.sendBeacon();
+
+			if (impl.block_for_beacon === true)
+				BOOMR.sendBeacon();
+
 			return this;
 		}
 
@@ -550,7 +566,15 @@ BOOMR.plugins.BW = {
 		}
 	},
 
-	is_complete: function() { return true; }
+	is_complete: function() {
+		if (impl.block_for_beacon === true)
+		{
+			return impl.complete;
+		}
+		else {
+			return true;
+		}
+	}
 };
 
 }());


### PR DESCRIPTION
Adds optional parameter to force the bandwidth plugin to block the beacon until it completes its test.  Added documentation where applicable as well to describe the behavior. 