### PR TITLE
fixes #74

### DIFF
--- a/boomerang.js
+++ b/boomerang.js
@@ -735,15 +735,17 @@ BOOMR_check_doc_domain();
 					document.body.appendChild(iframe);
 
                     // Add the form to the iframe
-                    var iFrmDocument = (iframe.contentWindow || iframe.contentDocument);
-                    if (iFrmDocument.document) iFrmDocument=iFrmDocument.document;
-                    if(iFrmDocument.body) {
-                        iFrmDocument.body.appendChild(form);
-                    }
-                    else {
-                        //body may be null, so add to the document
-                        iFrmDocument.appendChild(form);
-                    }
+					var iFrmDocument = (iframe.contentWindow || iframe.contentDocument);
+					if (iFrmDocument.document) {
+						iFrmDocument = iFrmDocument.document;
+					}
+					if (iFrmDocument.body) {
+						iFrmDocument.body.appendChild(form);
+					}
+					else {
+						//body may be null, so add to the document
+						iFrmDocument.appendChild(form);
+					}
 
 					try {
 						form.submit();

--- a/boomerang.js
+++ b/boomerang.js
@@ -734,8 +734,16 @@ BOOMR_check_doc_domain();
 
 					document.body.appendChild(iframe);
 
-					// Add the form to the iframe
-					iframe.appendChild(form);
+                    // Add the form to the iframe
+                    var iFrmDocument = (iframe.contentWindow || iframe.contentDocument);
+                    if (iFrmDocument.document) iFrmDocument=iFrmDocument.document;
+                    if(iFrmDocument.body) {
+                        iFrmDocument.body.appendChild(form);
+                    }
+                    else {
+                        //body may be null, so add to the document
+                        iFrmDocument.appendChild(form);
+                    }
 
 					try {
 						form.submit();

--- a/boomerang.js
+++ b/boomerang.js
@@ -734,7 +734,7 @@ BOOMR_check_doc_domain();
 
 					document.body.appendChild(iframe);
 
-                    // Add the form to the iframe
+					// Add the form to the iframe
 					var iFrmDocument = (iframe.contentWindow || iframe.contentDocument);
 					if (iFrmDocument.document) {
 						iFrmDocument = iFrmDocument.document;


### PR DESCRIPTION
Regarding #74, we can't add a form directly to a dynamic iframe.
contentWindow and contentDocument should be used. 